### PR TITLE
Modify gameday text logic

### DIFF
--- a/dist/ha-teamtracker-card.js
+++ b/dist/ha-teamtracker-card.js
@@ -82,8 +82,21 @@ class TeamTrackerCard extends LitElement {
 
     var t = new Translator(lang);
 
+    const rightNow = new Date();
+    const msInADay = 1000*60*60*24;
     var dateForm = new Date (stateObj.attributes.date);
+    var gameStartsInDays = (dateForm.getTime() - rightNow.getTime()) / (msInADay);
     var gameDay = dateForm.toLocaleDateString(lang, { weekday: 'long' });
+    var gameDateShort = "" ;
+    if (gameStartsInDays >= 7) {
+      gameDateShort = dateForm.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    }
+    if (gameStartsInDays >= 0 && gameStartsInDays < 1) {
+      gameDay = "Today";
+//    Think this should be as follows for locale support but results in
+//    "{Today}" printing and haven't figured out how to fix that.
+//    gameDay = t.translate("Today");
+    }
     var gameTime = dateForm.toLocaleTimeString(lang, { hour: '2-digit', minute:'2-digit' });
     if (time_format == "24") {
       gameTime = dateForm.toLocaleTimeString(lang, { hour: '2-digit', minute:'2-digit', hour12:false });
@@ -617,6 +630,7 @@ if (sport.includes("hockey")) {
                 </div>
                 <div class="gamewrapper">
                   <div class="gameday">${gameDay}</div>
+                  <div class="gameday">${gameDateShort}</div>
                   <div class="gametime">${gameTime}</div>
                 </div>
                 <div class="team">

--- a/dist/ha-teamtracker-card.js
+++ b/dist/ha-teamtracker-card.js
@@ -54,7 +54,7 @@ class TeamTrackerCard extends LitElement {
     var team = 1;
     var oppo = 2;
     if (((homeSide == "RIGHT") && (stateObj.attributes.team_homeaway == "home")) ||
-        ((homeSide == "LEFT")  && (stateObj.attributes.opponent_homeaway == "home"))) { 
+        ((homeSide == "LEFT")  && (stateObj.attributes.opponent_homeaway == "home"))) {
         team = 2;
         oppo = 1;
     }
@@ -82,20 +82,40 @@ class TeamTrackerCard extends LitElement {
 
     var t = new Translator(lang);
 
+    function dateDiff(first, second) {
+      return Math.round((second.getTime() - first.getTime()) / (1000 * 60 * 60 * 24));
+    }
+
+    function dateDiffWholeDays(first,second) {
+      var f = new Date(first.getTime());
+      var s = new Date(second.getTime());
+      f.setHours(0,0,0,0);
+      s.setHours(0,0,0,0);
+      return dateDiff(f,s);
+    }
+
+    function isToday(first, second) {
+      return dateDiffWholeDays(first,second) == 0;
+    }
+
+    function isTomorrow(first, second) {
+      return dateDiffWholeDays(first,second) == 1;
+    }
+
     const rightNow = new Date();
-    const msInADay = 1000*60*60*24;
     var dateForm = new Date (stateObj.attributes.date);
-    var gameStartsInDays = (dateForm.getTime() - rightNow.getTime()) / (msInADay);
     var gameDay = dateForm.toLocaleDateString(lang, { weekday: 'long' });
     var gameDateShort = "" ;
-    if (gameStartsInDays >= 7) {
-      gameDateShort = dateForm.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    if (dateDiff(rightNow,dateForm) >= 7) {
+      gameDateShort = dateForm.toLocaleDateString(lang, { month: 'short', day: 'numeric' });
     }
-    if (gameStartsInDays >= 0 && gameStartsInDays < 1) {
-      gameDay = "Today";
-//    Think this should be as follows for locale support but results in
-//    "{Today}" printing and haven't figured out how to fix that.
-//    gameDay = t.translate("Today");
+    else if (isToday(rightNow,dateForm)) {
+      gameDay = t.translate("common.today");
+      gameDateShort= dateForm.toLocaleDateString(lang, { weekday: 'long' });
+    }
+    else if (isTomorrow(rightNow,dateForm)) {
+      gameDay = t.translate("common.tomorrow");
+      gameDateShort= dateForm.toLocaleDateString(lang, { weekday: 'long' });
     }
     var gameTime = dateForm.toLocaleTimeString(lang, { hour: '2-digit', minute:'2-digit' });
     if (time_format == "24") {
@@ -167,7 +187,7 @@ class TeamTrackerCard extends LitElement {
         </style>
         <ha-card>
           Sensor unavailable: ${this._config.entity}
-        </ha-card> 
+        </ha-card>
       `;
     }
 //
@@ -258,7 +278,7 @@ class TeamTrackerCard extends LitElement {
           notFoundTerm2 = t.translate("common.no_upcoming_games", "%s", lastDateForm.toLocaleDateString(lang))
         }
     }
-    
+
 //
 //  MLB Specific Changes
 //
@@ -334,7 +354,7 @@ if (sport.includes("hockey")) {
       barDisplay = 'none';
       barWrapDisplay = "none";
     }
-  
+
 //
 //  Tennis Specific Changes
 //
@@ -390,7 +410,7 @@ if (sport.includes("hockey")) {
         finalTerm = finalTerm + " (" + stateObj.attributes.quarter + ")";
       }
       timeoutsDisplay = 'none';
-      
+
       barLength[team] = stateObj.attributes.team_total_shots;
       barLength[oppo] = stateObj.attributes.team_total_shots;
       barLabel[team] = t.translate("racing.teamBarLabel", "%s", String(stateObj.attributes.team_total_shots));
@@ -430,7 +450,7 @@ if (sport.includes("hockey")) {
     if (stateObj.attributes.league.includes("NCAA")) {
       notFoundLogo = 'https://a.espncdn.com/i/espn/misc_logos/500/ncaa.png'
     }
-    
+
     if (stateObj.state == 'POST') {
       return html`
         <style>
@@ -714,3 +734,4 @@ if (sport.includes("hockey")) {
 }
 
 customElements.define("teamtracker-card", TeamTrackerCard);
+

--- a/dist/ha-teamtracker-card.js
+++ b/dist/ha-teamtracker-card.js
@@ -607,6 +607,7 @@ if (sport.includes("hockey")) {
             .rank { font-size:0.8em; display:${rankDisplay}; }
             .line { height: 1px; background-color: var(--primary-text-color); margin:10px 0; }
             .gameday { font-size: 1.4em; margin-bottom: 4px; }
+            .gamedateshort { font-size: 1.1em; }
             .gametime { font-size: 1.1em; }
             .sub1 { font-weight: 500; font-size: 1.2em; margin: 6px 0 2px; }
             .sub1, .sub2, .sub3 { display: flex; justify-content: space-between; align-items: center; margin: 2px 0; }
@@ -630,7 +631,7 @@ if (sport.includes("hockey")) {
                 </div>
                 <div class="gamewrapper">
                   <div class="gameday">${gameDay}</div>
-                  <div class="gameday">${gameDateShort}</div>
+                  <div class="gamedateshort">${gameDateShort}</div>
                   <div class="gametime">${gameTime}</div>
                 </div>
                 <div class="team">

--- a/dist/localize/languages/en.js
+++ b/dist/localize/languages/en.js
@@ -11,7 +11,9 @@ export const en = {
         "tourney32": "Round of 32",
         "tourney64": "Round of 64",
         "tourney128": "Early Rounds",
-        "tourney256": "Early Rounds"
+        "tourney256": "Early Rounds",
+        "today": "Today",
+        "tomorrow": "Tomorrow"
     },
     "australian-football": {
         "startTerm": "Start",

--- a/dist/localize/languages/en_US.js
+++ b/dist/localize/languages/en_US.js
@@ -11,7 +11,9 @@ export const en_US = {
         "tourney32": "Round of 32",
         "tourney64": "Round of 64",
         "tourney128": "Early Rounds",
-        "tourney256": "Early Rounds"
+        "tourney256": "Early Rounds",
+        "today": "Today",
+        "tomorrow": "Tomorrow"
     },
     "australian-football": {
         "startTerm": "Start",

--- a/dist/localize/languages/es.js
+++ b/dist/localize/languages/es.js
@@ -11,7 +11,9 @@ export const es = {
         "tourney32": "Ronda de 32",
         "tourney64": "Ronda de 64",
         "tourney128": "Primeras Rondas",
-        "tourney256": "Primeras Rondas"
+        "tourney256": "Primeras Rondas",
+        "today": "Hoy",
+        "tomorrow": "Mañana"
     },
     "australian-football": {
         "startTerm": "Comienzo",

--- a/dist/localize/languages/es_419.js
+++ b/dist/localize/languages/es_419.js
@@ -11,7 +11,9 @@ export const es_419 = {
         "tourney32": "Ronda de 32",
         "tourney64": "Ronda de 64",
         "tourney128": "Primeras Rondas",
-        "tourney256": "Primeras Rondas"
+        "tourney256": "Primeras Rondas",
+        "today": "Hoy",
+        "tomorrow": "Mañana"
     },
     "australian-football": {
         "startTerm": "Comienzo",

--- a/dist/localize/languages/pt_BR.js
+++ b/dist/localize/languages/pt_BR.js
@@ -3,7 +3,9 @@ export const pt_BR = {
         "api_error": "Erro de API",
         "no_upcoming_games": "Sem próximos jogos %s",
         "finalTerm": "%s - Final",
-        "byeTerm": "DESCANSO"
+        "byeTerm": "DESCANSO",
+        "today": "Hoje",
+        "tomorrow": "Amanhã"
     },
     "baseball": {
         "startTerm": "Começa",


### PR DESCRIPTION
Show short month plus numeric day if game not occurring within a week. Show "Today" if the game is occurring today. This helps avoid any confusion at first glance when the day of the week is shown.

Note: had trouble with the translate function of the Translator, so hardcoded this English. I'm not familiar with this, so may be an easy fix to have this display properly and include locale support.