### PR TITLE
Fix for outage at unpkg.com

### DIFF
--- a/dist/ha-teamtracker-card.js
+++ b/dist/ha-teamtracker-card.js
@@ -1,4 +1,5 @@
-import { html, LitElement } from "https://unpkg.com/lit?module";
+//import { html, LitElement } from "https://unpkg.com/lit?module";
+import { html, LitElement } from "https://cdn.jsdelivr.net/gh/lit/dist@2/core/lit-core.min.js";
 import { Translator } from "./localize/translator.js";
 
 class TeamTrackerCard extends LitElement {


### PR DESCRIPTION
Currently, unpkg.com is having some issues with their CDN. My card (firemote) was having issues reported as well.  This pull request uses a different source for the Lit Package import.