### PR TITLE
Issue with a French translation

### DIFF
--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -111,7 +111,7 @@ export const fr = {
         "gameStat1": "%s",
         "gameStat2": "%s",
         "gameStat3": "",
-        "gameBar": "Tirs (cadrer)",
+        "gameBar": "Tirs (cadrés)",
         "teamBarLabel": "%s",
         "oppoBarLabel": "%s"
     },


### PR DESCRIPTION
Cadrer is the verb in its infinitive form
"Tirs cadrés" is the correct translation for Shots on target